### PR TITLE
Colorize blank background to match code style

### DIFF
--- a/library/src/main/java/com/pddstudio/highlightjs/utils/SourceUtils.java
+++ b/library/src/main/java/com/pddstudio/highlightjs/utils/SourceUtils.java
@@ -42,7 +42,7 @@ public class SourceUtils {
 				"    <script>hljs.initHighlightingOnLoad();</script>\n" +
 				(showLineNumbers ? "<script>hljs.initLineNumbersOnLoad();</script>\n" : "") +
 				"</head>\n" +
-				"<body style=\"margin: 0; padding: 0\">\n";
+				"<body style=\"margin: 0; padding: 0\" class=\"hljs\">\n";
 	}
 
 	private static String getLineNumberStyling() {


### PR DESCRIPTION
This pull request changes the color of the whole web-view background to be styled exactly like the background of the code fragment.

# Before
<img src="https://user-images.githubusercontent.com/5156340/38555041-0b3b695a-3cc5-11e8-8644-04c4136d4303.png" alt="background before" height="580" />

# After
<img src="https://user-images.githubusercontent.com/5156340/38555040-0b19a824-3cc5-11e8-959a-21fa2dabe5e0.png" alt="background after" height="580" />

