### PR TITLE
Get rid of blank margin at the top of view

### DIFF
--- a/library/src/main/java/com/pddstudio/highlightjs/utils/SourceUtils.java
+++ b/library/src/main/java/com/pddstudio/highlightjs/utils/SourceUtils.java
@@ -33,6 +33,9 @@ public class SourceUtils {
 				"           margin: 0px;\n" +
 				"           padding: 0px;\n" +
 				"       }\n" +
+				"       pre {\n" +
+				"           margin: 0;\n" +
+				"       }\n" +
 				"   </style>\n";
 	}
 


### PR DESCRIPTION
This pull request removes the small blank space visible at the top of the view above code fragment.

# Before
<img src="https://user-images.githubusercontent.com/5156340/38555041-0b3b695a-3cc5-11e8-8644-04c4136d4303.png" alt="margin before" height="580" />

# After
<img src="https://user-images.githubusercontent.com/5156340/38555313-f358eeec-3cc5-11e8-934c-d7fe6945b18f.png" alt="margin after" height="580" />